### PR TITLE
Update main dependencies

### DIFF
--- a/src/leiningen/new/devcards/project.clj
+++ b/src/leiningen/new/devcards/project.clj
@@ -7,20 +7,20 @@
   :min-lein-version "2.5.3"
   
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.clojure/clojurescript "1.8.51"]
+                 [org.clojure/clojurescript "1.9.93"]
                  [devcards "0.2.1-7"]
-                 [sablono "0.7.1"]
+                 [sablono "0.7.3"]
                  
                  ;; need to specify this for sablono
                  ;; when not using devcards
-                 [cljsjs/react "15.0.2-0"]
-                 [cljsjs/react-dom "15.0.2-0"]
-                 [cljsjs/react-dom-server "15.0.2-0"]
+                 [cljsjs/react "15.2.1-1"]
+                 [cljsjs/react-dom "15.2.1-1"]
+                 [cljsjs/react-dom-server "15.2.1-1"]
                  #_[org.omcljs/om "0.9.0"]
                  #_[reagent "0.5.1"]
                  ]
 
-  :plugins [[lein-figwheel "0.5.3-2"]
+  :plugins [[lein-figwheel "0.5.4-7"]
             [lein-cljsbuild "1.1.3" :exclusions [org.clojure/clojure]]]
 
   :clean-targets ^{:protect false} ["resources/public/js/compiled"


### PR DESCRIPTION
Updated dependencies for all but om and reagent. 
Tested with reagent BMI calculator demo from devcards/devdemos and no problems found.
Error with om demos, but most likely related to my lack of om experience, but it may be worth testing before accepting.
